### PR TITLE
Fix minio_s3_url_domain args

### DIFF
--- a/amazon-s3-and-cloudfront-tweaks.php
+++ b/amazon-s3-and-cloudfront-tweaks.php
@@ -73,7 +73,7 @@ class Amazon_S3_and_CloudFront_Tweaks {
 		 */
 		//add_filter( 'as3cf_aws_s3_client_args', array( $this, 'minio_s3_client_args' ) );
 		//add_filter( 'as3cf_aws_get_regions', array( $this, 'minio_get_regions' ) );
-		//add_filter( 'as3cf_aws_s3_url_domain', array( $this, 'minio_s3_url_domain' ), 10, 6 );
+		//add_filter( 'as3cf_aws_s3_url_domain', array( $this, 'minio_s3_url_domain' ), 10, 5 );
 		//add_filter( 'as3cf_upload_acl', array( $this, 'minio_upload_acl' ), 10, 1 );
 		//add_filter( 'as3cf_upload_acl_sizes', array( $this, 'minio_upload_acl' ), 10, 1 );
 		//add_filter( 'as3cf_aws_s3_console_url', array( $this, 'minio_s3_console_url' ) );
@@ -311,7 +311,7 @@ class Amazon_S3_and_CloudFront_Tweaks {
 	 *
 	 * @return string
 	 */
-	function minio_s3_url_domain( $domain, $bucket, $region, $expires, $args, $preview ) {
+	function minio_s3_url_domain( $domain, $bucket, $region, $expires, $args ) {
 		// MinIO doesn't need a region prefix, and always puts the bucket in the path.
 		return '127.0.0.1:54321/' . $bucket;
 	}

--- a/amazon-s3-and-cloudfront-tweaks.php
+++ b/amazon-s3-and-cloudfront-tweaks.php
@@ -307,7 +307,6 @@ class Amazon_S3_and_CloudFront_Tweaks {
 	 * @param string $region
 	 * @param int    $expires
 	 * @param array  $args    Allows you to specify custom URL settings
-	 * @param bool   $preview When generating the URL preview sanitize certain output
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
I fixed argument in minio_s3_url_domain.
amazon-s3-and-cloudfront 2.4.1 has 5 arguments, and to fit "amazon-s3-and-cloudfront" modify recieve argument.

environment: 
  wordpress 5.5
  amazon-s3-and-cloudfront        2.4.1
  amazon-s3-and-cloudfront-tweaks 0.4.0

debug messages: 
[15-Aug-2020 01:24:07 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Amazon_S3_and_CloudFront_Tweaks::minio_s3_url_domain(), 5 passed in /home/www/wp-includes/class-wp-hook.php on line 287 and exactly 6 expected in /home/www/wp-content/plugins/amazon-s3-and-cloudfront-tweaks/amazon-s3-and-cloudfront-tweaks.php:314
Stack trace:
#0 /home/www/wp-includes/class-wp-hook.php(287): Amazon_S3_and_CloudFront_Tweaks->minio_s3_url_domain()
#1 /home/www/wp-includes/plugin.php(206): WP_Hook->apply_filters()
#2 /home/www/wp-content/plugins/amazon-s3-and-cloudfront/classes/providers/storage/storage-provider.php(664): apply_filters()
#3 /home/www/wp-content/plugins/amazon-s3-and-cloudfront/classes/amazon-s3-and-cloudfront.php(2456): DeliciousBrains\WP_Offload_Media\Providers\Storage\Storage_Provider->get_url_domain()
#4 /home/www/wp-content/plugins/amazon-s3-and-cloudfront/classes/amazon-s3-and-cloudfront.php(2328): Amazon_S3_And_CloudFront->get_attachment_provider_url()
#5 /home/www/wp-content/plugins/amazon-s3-and-cloudfront/classes in /home/www/wp-content/plugins/amazon-s3-and-cloudfront-tweaks/amazon-s3-and-cloudfront-tweaks.php on line 314
